### PR TITLE
Fix console output

### DIFF
--- a/bin/omniscli.ps1
+++ b/bin/omniscli.ps1
@@ -75,7 +75,7 @@ function flushStream ([System.IO.StreamReader]${file_stream}, [System.IO.StreamW
     while (-not ${file_stream}.EndOfStream) {
         ${output}.Write([char]${file_stream}.Read())
     }
-    ${output}.Flush()
+    ${output}.Flush() 
 }
 
 function flushConsole {

--- a/bin/omniscli.ps1
+++ b/bin/omniscli.ps1
@@ -75,6 +75,7 @@ function flushStream ([System.IO.StreamReader]${file_stream}, [System.IO.StreamW
     while (-not ${file_stream}.EndOfStream) {
         ${output}.Write([char]${file_stream}.Read())
     }
+    ${output}.Flush()
 }
 
 function flushConsole {


### PR DESCRIPTION
On Windows Server 2019 using Powershell version 5.1.17763.3770 there was no output to the console even though Omnis was writing to the run\std*.txt files.   The output only appeared after closing Omnis.
I played around with the powershell script and added ${output}.Flush() to function flushStream to resolve.