### PR TITLE
Fix incorrect formatting of quoted Omnis args in Powershell script

### DIFF
--- a/bin/omniscli.ps1
+++ b/bin/omniscli.ps1
@@ -23,7 +23,7 @@ if (-not (Test-Path ${path_to_omnis})) {
 }
 
 # Build omniscli arguments, quoted
-${quoted_args} = "'" + ${omniscli_args} -join "' '" + "'"
+${quoted_args} = "'" + (${omniscli_args} -join "' '") + "'"
 $env:OMNISCLI_ARGUMENTS = ${command} + ' ' + ${quoted_args}
 
 # Get paths


### PR DESCRIPTION
omniscli.ps1 quotes all arguments intended for the Omnis library. This small change fixes the way these arguments are joined together.

Before:
```
PS C:\Development\omniscli\bin> .\omniscli.ps1 "C:\Program Files\Omnis Software\OS 10.22 31840" command arg1 arg2 arg3
$env:OMNISCLI_ARGUMENTS = command 'arg1 arg2 arg3
```

After:
```
PS C:\Development\omniscli\bin> .\omniscli.ps1 "C:\Program Files\Omnis Software\OS 10.22 31840" command arg1 arg2 arg3
$env:OMNISCLI_ARGUMENTS = command 'arg1' 'arg2' 'arg3'
```